### PR TITLE
239 Commas to dots

### DIFF
--- a/frontend/antibiootit/src/components/Form.js
+++ b/frontend/antibiootit/src/components/Form.js
@@ -313,7 +313,7 @@ export default function Form(props) {
                 
                 props.setIsWeightOk(true);
                 setWeight(formattedWeight);
-                props.setChosenWeight(formattedWeight);
+                props.setChosenWeight(weightForCalculations);
                 setFormatWeight(true);
 
                 const data = { 


### PR DESCRIPTION
Replace the decimal delimiters from commas to dots in the formula view.
This was caused by setting the `chosenWeight` as formatted value instead of `weightForCalculations` as was used elsewhere.